### PR TITLE
feat: adding support for context repo setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This example demonstrates how to use a complete cycle to establish a connection 
 - [ ] Develop unit tests for key functions in `codypy`.
 - [x] Create documentation and examples for using the `codypy` client library.
 - [ ] Implement support for including additional context about files and folders.
+- [x] Configure repository context.
 
 
 ## License

--- a/main.py
+++ b/main.py
@@ -54,6 +54,13 @@ async def main():
         is_debugging=False,
     )
 
+    # Set the repository context
+    print(f"{YELLOW}--- Set context repo ---{RESET}")
+    await cody_agent.set_context_repo(
+        repos=["github.com/sourcegraph/cody", "github.com/PriNova/codypy"],
+        is_debugging=False,
+    )
+
     # Send a message to the chat and print the response until the user enters '/quit'.
     print(f"{YELLOW}--- Send message (short) ---{RESET}")
     debug_method_map["webview/postMessage"] = False


### PR DESCRIPTION
- Add method to resolve repository names to repository objects. This is done via a small caching layer to allow multiple context switches without needing to continuously lookup the same objects.
- Add method to set chat context repository
- Update README with the new feature
- Add examples in main.py for the context repo configuration