### PR TITLE
refactor(cody_py): Stripping down CodyServer class

### DIFF
--- a/codypy/__init__.py
+++ b/codypy/__init__.py
@@ -22,7 +22,6 @@ from .config import (
     get_debug_map,
 )
 from .context import append_paths
-from .logger import log_message, setup_logger
 from .server_info import AuthStatus, CodyAgentSpecs, CodyLLMSiteConfiguration
 
 __all__ = [
@@ -50,6 +49,4 @@ __all__ = [
     "CYAN",
     "WHITE",
     "append_paths",
-    "setup_logger",
-    "log_message",
 ]

--- a/codypy/cli.py
+++ b/codypy/cli.py
@@ -1,27 +1,38 @@
+"""
+Simple CLI wrapper to interact with Cody from shell
+"""
+
 import argparse
 import asyncio
+import logging
 import os
 
-from codypy.client_info import AgentSpecs
-from codypy.cody_py import CodyAgent, CodyServer
-from codypy.config import debug_method_map
+from .client_info import AgentSpecs
+from .cody_py import CodyAgent, CodyServer
+from .config import debug_method_map
 
 
-async def async_main():
+def get_args() -> argparse.Namespace:
+    """Create an argument parser"""
+
     parser = argparse.ArgumentParser(description="Cody Agent Python CLI")
-    parser.add_argument("chat", help="Initialize the chat conversation")
+    parser.add_argument(
+        "chat", help="Initialize the chat conversation", action="store_true"
+    )
+    parser.add_argument(
+        "download", help="Download the cody-agent binary", action="store_true"
+    )
     parser.add_argument(
         "--binary_path",
         type=str,
-        required=True,
+        required=False,
         default=os.getenv("BINARY_PATH"),
         help="The path to the Cody Agent binary. (Required)",
     )
-
     parser.add_argument(
         "--access_token",
         type=str,
-        required=True,
+        required=False,
         default=os.getenv("SRC_ACCESS_TOKEN"),
         help="The Sourcegraph access token. (Needs to be exported as SRC_ACCESS_TOKEN) (Required)",
     )
@@ -38,7 +49,12 @@ async def async_main():
         default=os.path.abspath(os.getcwd()),
         help=f"The current working directory. Default={os.path.abspath(os.getcwd())}",
     )
-
+    parser.add_argument(
+        "--endpoint",
+        type=str,
+        default=os.getenv("SRC_ENDPOINT", "https://sourcegraph.com"),
+        help="Sourcegraph endpoint (Default: https://sourcegraph.com)",
+    )
     parser.add_argument(
         "-ec",
         "--enhanced-context",
@@ -53,20 +69,30 @@ async def async_main():
         default=False,
         help="Show the inferred context files from the message if any. Default=True",
     )
-
-    args = parser.parse_args()
-    await chat(args)
-
-
-async def chat(args):
-    cody_server: CodyServer = await CodyServer.init(
-        binary_path=args.binary_path, version="0.0.5b", is_debugging=False
+    parser.add_argument(
+        "--loglevel",
+        help="Set the log level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="WARNING",
     )
-    # Create an AgentSpecs instance with the specified workspace root URI and extension configuration.
+
+    return parser.parse_args()
+
+
+async def chat(args: argparse.Namespace):
+    """Send a chat message to cody and retrieve the response"""
+
+    # Create a CodyServer instance
+    cody_server: CodyServer = CodyServer(cody_binary=args.binary_path)
+    await cody_server.connect()
+
+    # Create an AgentSpecs instance with the specified workspace root URI
+    # and extension configuration.
     agent_specs = AgentSpecs(
         workspaceRootUri=args.workspace_root_uri,
         extensionConfiguration={
             "accessToken": args.access_token,
+            "serverEndpoint": args.endpoint,
             "codebase": "",  # github.com/sourcegraph/cody",
             "customConfiguration": {},
         },
@@ -80,8 +106,8 @@ async def chat(args):
     debug_method_map["webview/postMessage"] = False
     response = await cody_agent.chat(
         message=args.message,
-        enhanced_context=args.ec,
-        show_context_files=args.sc,
+        enhanced_context=args.enhanced_context,
+        show_context_files=args.show_context,
         is_debugging=False,
     )
     if response == "":
@@ -95,7 +121,13 @@ async def chat(args):
 
 
 def main():
-    asyncio.run(async_main())
+    """Main program"""
+    args = get_args()
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(filename)s:%(funcName)s - %(message)s",
+        level=getattr(logging, args.loglevel),
+    )
+    asyncio.run(chat(args))
 
 
 if __name__ == "__main__":

--- a/codypy/cody_py.py
+++ b/codypy/cody_py.py
@@ -1,143 +1,91 @@
 import asyncio
+import logging
 import os
 import sys
 from asyncio.subprocess import Process
-from typing import Any, Self
+from typing import Any
 
 from codypy.client_info import AgentSpecs, Models
-from codypy.logger import log_message
-from codypy.utils import (
-    _check_for_binary_file,
-    _download_binary_to_path,
-    _format_binary_name,
-)
 
-from .config import BLUE, RED, RESET, YELLOW, Configs, debug_method_map
+from .config import RED, RESET, YELLOW, Configs, debug_method_map
 from .messaging import _send_jsonrpc_request, _show_last_message, request_response
 from .server_info import CodyAgentSpecs
 
+logger = logging.getLogger(__name__)
+
 
 class CodyServer:
-    async def init(
-        binary_path: str,
-        version: str,
-        use_tcp: bool = False,  # default because of ca-certificate verification
-        is_debugging: bool = False,
-    ) -> Self:
-        cody_binary = ""
-        test_against_node_source: bool = (
-            False  # Only for internal use to test against the Cody agent Node source
-        )
-        if not test_against_node_source:
-            has_agent_binary = await _check_for_binary_file(
-                binary_path, "cody-agent", version
-            )
-            if not has_agent_binary:
-                log_message(
-                    "CodyServer: init:",
-                    f"WARNING: The Cody Agent binary does not exist at the specified path: {binary_path}",
-                )
-                print(
-                    f"{YELLOW}WARNING: The Cody Agent binary does not exist at the specified path: {binary_path}{RESET}"
-                )
-                print(
-                    f"{YELLOW}WARNING: Start downloading the Cody Agent binary...{RESET}"
-                )
-                is_completed = await _download_binary_to_path(
-                    binary_path, "cody-agent", version
-                )
-                if not is_completed:
-                    log_message(
-                        "CodyServer: init:",
-                        "ERROR: Failed to download the Cody Agent binary.",
-                    )
-                    print(
-                        f"{RED}ERROR: Failed to download the Cody Agent binary.{RESET}"
-                    )
-                    sys.exit(1)
+    """Asynchronous I/O wrapper around Cody agent binary
 
-            cody_binary = os.path.join(
-                binary_path, await _format_binary_name("cody-agent", version)
-            )
+    :param cody_binary str: Path of the Cody agent binary
+        To test against the cody agent source, you have set `cody_binary` as
+        an empty string and set CODYPY_CODY_CMD environment variable with the
+        full node command.
+    :use_tcp bool: Enables agent communication via TCP socket via env var
+                   CODY_AGENT_DEBUG_REMOTE. By default this is turned off
+                   and communication is via process stdin/stdout.
+    :param debug bool: Enables Cody agent debugging via env var CODY_DEBUG.
+    """
 
-        cody_agent = CodyServer(cody_binary, use_tcp, is_debugging)
-        await cody_agent._create_server_connection(test_against_node_source)
-        return cody_agent
-
-    def __init__(self, cody_binary: str, use_tcp: bool, is_debugging: bool) -> None:
-        self.cody_binary = cody_binary
+    def __init__(
+        self, cody_binary: str, use_tcp: bool = False, is_debugging: bool = False
+    ) -> None:
+        self.cody_binary: str = cody_binary
         self.use_tcp = use_tcp
         self.is_debugging = is_debugging
         self._process: Process | None = None
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
+        self._binary_path: str
+        self._binary_args: tuple[str, ...]
+        self._binary_path, self._binary_args = self._prepare_binary()
 
-    async def _create_server_connection(
-        self, test_against_node_source: bool = False
-    ) -> None:
+    def _prepare_binary(self) -> tuple[str, tuple[str, ...]]:
+        """Find the right binary to use with the commands
+
+        This function is mainly here to enable testability against
+        Cody agent node source code directly instead of the binary
+
+        In order to test against the compiled Cody agent source code,
+        you can set CODYPY_CODY_CMD environment variable. Example:
+        export CODYPY_CODY_CMD="node --enable-source-maps ~/CodeProjects/cody/agent/dist/index.js"
         """
-        Asynchronously creates a connection to the Cody server.
-        If `cody_binary` is an empty string, it prints an error message and exits the program.
-        Sets the `CODY_AGENT_DEBUG_REMOTE` and `CODY_DEBUG` environment variables based on the `use_tcp` and `is_debugging` flags, respectively.
-        Creates a subprocess to run the Cody agent, either by executing the `bin/agent` binary or running the `index.js` file specified by `binary_path`.
-        Depending on the `use_tcp` flag, it either connects to the agent using stdio or opens a TCP connection to `localhost:3113`.
-        If the TCP connection fails after 5 retries, it prints an error message and exits the program.
-        Returns the reader and writer streams for the agent connection.
+
+        if custom_cmd := os.getenv("CODYPY_CODY_CMD"):
+            logger.warning("Using custom cody command: %s", custom_cmd)
+            tokens = custom_cmd.split(" ")
+            return tokens[0], tuple(tokens[1:] + ["jsonrpc"])
+
+        if not os.path.isfile(self.cody_binary):
+            raise FileNotFoundError(
+                "Cody binary at %s not found. Either fix the path "
+                "or download the binary with `codypy download`"
+            )
+        return self.cody_binary, ("jsonrpc",)
+
+    async def connect(self) -> None:
+        """Asynchronously creates a connection to the Cody server
+
+        If the TCP connection is enabled, connection will be attempted 5 times
+        before raising a ConnectionFailedError.
         """
-        if not test_against_node_source and self.cody_binary == "":
-            log_message(
-                "CodyServer: _create_server_connection:",
-                "ERROR: The Cody Agent binary path is empty.",
-            )
-            print(
-                f"{RED}You need to specify the BINARY_PATH to an absolute path to the agent binary or to the index.js file. Exiting...{RESET}"
-            )
-            sys.exit(1)
 
-        os.environ["CODY_AGENT_DEBUG_REMOTE"] = str(self.use_tcp).lower()
-        os.environ["CODY_DEBUG"] = str(self.is_debugging).lower()
-
-        args = []
-        binary = ""
-        if test_against_node_source:
-            binary = "node"
-            args.extend(
-                (
-                    "--enable-source-maps",
-                    "/home/prinova/CodeProjects/cody/agent/dist/index.js",
-                )
-            )
-        else:
-            binary = self.cody_binary
-        args.append("jsonrpc")
         self._process: Process = await asyncio.create_subprocess_exec(
-            binary,
-            *args,
+            self._binary_path,
+            *self._binary_args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            env=os.environ,
+            env={
+                "CODY_AGENT_DEBUG_REMOTE": str(self.use_tcp).lower(),
+                "CODY_DEBUG": str(self.is_debugging).lower(),
+            },
         )
 
         self._reader = self._process.stdout
         self._writer = self._process.stdin
 
-        if not self.use_tcp:
-            log_message(
-                "CodyServer: _create_server_connection:",
-                "Created a stdio connection to the Cody agent.",
-            )
-            if self.is_debugging:
-                print(f"{YELLOW}--- stdio connection ---{RESET}")
-            self._reader = self._process.stdout
-            self._writer = self._process.stdin
-
-        else:
-            log_message(
-                "CodyServer: _create_server_connection:",
-                "Created a TCP connection to the Cody agent.",
-            )
-            if self.is_debugging:
-                print(f"{YELLOW}--- TCP connection ---{RESET}")
+        if self.use_tcp:
+            logger.info("Initializing TCP connection to the Cody agent.")
             retry: int = 0
             retry_attempts: int = 5
             for retry in range(retry_attempts):
@@ -145,25 +93,19 @@ class CodyServer:
                     (self._reader, self._writer) = await asyncio.open_connection(
                         "localhost", 3113
                     )
-                    if self._reader is not None and self._writer is not None:
-                        log_message(
-                            "CodyServer: _create_server_connection:",
-                            "Connected to server: localhost:3113",
-                        )
-                        print(f"{YELLOW}Connected to server: localhost:3113{RESET}\n")
-                        break
-
-                    # return reader, writer, process
+                    if self._reader and self._writer:
+                        logger.info("Connected to server: localhost:3113")
+                        return
                 except ConnectionRefusedError:
-                    await asyncio.sleep(1)  # Retry after a short delay
+                    # Retry after a short delay
+                    await asyncio.sleep(1)
                     retry += 1
             if retry == retry_attempts:
-                log_message(
-                    "CodyServer: _create_server_connection:",
-                    "Could not connect to server. Exiting...",
+                raise ConnectionRefusedError(
+                    f"Failed to connect to localhost:3113 after {retry} attempts."
                 )
-                print(f"{RED}Could not connect to server. Exiting...{RESET}")
-                sys.exit(1)
+        else:
+            logger.info("Created a stdio connection to the Cody agent.")
 
     async def initialize_agent(
         self,
@@ -192,33 +134,20 @@ class CodyServer:
         )
 
         cody_agent_specs: CodyAgentSpecs = CodyAgentSpecs.model_validate(response)
-        log_message(
-            "CodyServer: initialize_agent:",
-            f"Agent Info: {cody_agent_specs}",
-        )
-        if is_debugging:
-            print(f"Agent Info: {cody_agent_specs}\n")
-        if cody_agent_specs.authenticated:
-            log_message(
-                "CodyServer: initialize_agent:",
-                "Server is authenticated.",
-            )
-            print(f"{YELLOW}--- Server is authenticated ---{RESET}")
-        else:
-            log_message(
-                "CodyServer: initialize_agent:",
-                "Server is not authenticated.",
-            )
-            print(f"{RED}--- Server is not authenticated ---{RESET}")
+        logger.debug("Agent Info: %s", cody_agent_specs)
+        if not cody_agent_specs.authenticated:
+            logger.error("Server is not authenticated.")
             await self.cleanup_server()
-            sys.exit(1)
-        return await CodyAgent.init(self)
+            raise SystemError("Failed to authenticate to Cody agent")
+
+        logger.info("Server is authenticated.")
+        return CodyAgent(self)
 
     async def cleanup_server(self):
         """
         Cleans up the server connection by sending a "shutdown" request to the server and terminating the server process if it is still running.
         """
-        log_message("CodyServer: cleanup_server:", "Cleanup Server...")
+        logger.debug("Cleanup Server...")
         await _send_jsonrpc_request(self._writer, "shutdown", None)
         if self._process.returncode is None:
             self._process.terminate()
@@ -231,9 +160,6 @@ class CodyAgent:
         self.chat_id: str | None = None
         self.repos: dict = {}
         self.current_repo_context: list[str] = []
-
-    async def init(cody_client: CodyServer):
-        return CodyAgent(cody_client)
 
     async def new_chat(
         self, debug_method_map=debug_method_map, is_debugging: bool = False
@@ -454,10 +380,7 @@ class CodyAgent:
             result, show_context_files, is_debugging
         )
         if speaker == "" or response == "":
-            log_message(
-                "CodyAgent: chat:",
-                f"Failed to submit chat message: {result}",
-            )
+            logger.error("Failed to submit chat message: %s", result)
             debug_method_map["webview/postMessage"] = True
             return f"{RED}--- Failed to submit chat message ---{RESET}"
         debug_method_map["webview/postMessage"] = True

--- a/codypy/context.py
+++ b/codypy/context.py
@@ -1,7 +1,8 @@
+import logging
 import os
 from dataclasses import dataclass
 
-from codypy.logger import log_message
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -31,7 +32,7 @@ def append_paths(*paths: str) -> list[Context]:
     """
     for path in paths:
         if not os.path.exists(path):
-            log_message("append_paths", f"WARNING: The path {path} does not exist.")
+            logger.warning("The path %s does not exist.", path)
 
         uri = Uri()
         uri.fsPath = path

--- a/codypy/messaging.py
+++ b/codypy/messaging.py
@@ -1,13 +1,16 @@
 import asyncio
+import logging
 from json import JSONDecodeError
 from typing import Any, AsyncGenerator, Dict, Tuple
 
 import pydantic_core as pd
 
 from codypy.config import Configs
-from codypy.logger import log_message
 
 MESSAGE_ID = 1
+
+
+logger = logging.getLogger(__name__)
 
 
 async def _send_jsonrpc_request(
@@ -265,6 +268,7 @@ async def request_response(
     Returns:
         Any: The result of the JSON-RPC request, or None if no result is available.
     """
+    logger.debug("Sending command: %s - %s", method_name, params)
     await _send_jsonrpc_request(writer, method_name, params)
     async for response in _handle_server_respones(reader):
         recieved_method_name = (
@@ -275,9 +279,9 @@ async def request_response(
                 recieved_method_name in debug_method_map
                 and debug_method_map[recieved_method_name]
             ):
-                log_message("Messaging: request_response: ", f"{response}")
+                logger.debug("Messaging: request_response: %s", response)
             if recieved_method_name not in debug_method_map:
-                log_message("Messaging: request_response: ", f"{response}")
+                logger.debug("Messaging: request_response: %s", response)
 
         if is_debugging and await _has_method(response):
             if (
@@ -289,7 +293,7 @@ async def request_response(
                 print(f"Response: \n\n{response}\n")
 
         if response and await _has_result(response):
-            log_message("Messaging: request_response: ", response)
+            logger.info("Messaging: request_response: %s", response)
             if is_debugging:
                 print(f"Result: \n\n{response}\n")
 

--- a/main.py
+++ b/main.py
@@ -24,9 +24,8 @@ async def main():
     # with the specified binary path and debugging mode.
     log_message("main:", "--- Create Server Connection ---")
     print(f"{YELLOW}--- Create Server Connection ---{RESET}")
-    cody_server: CodyServer = await CodyServer.init(
-        binary_path=BINARY_PATH, version="0.0.5b", is_debugging=False
-    )
+    cody_server: CodyServer = await CodyServer(binary_path=BINARY_PATH)
+    await CodyServer.connect()
 
     # Create an AgentSpecs instance with the specified workspace root URI
     # and extension configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,8 @@ dev = [
 documentation = "https://github.com/PriNova/codypy/blob/main/README.md"
 repository = "https://github.com/PriNova/codypy"
 
+[project.scripts]
+codypy = "codypy.cli:main"
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- Simplified the case of testing node cody source code directly
- Removed the download functionality from CodyServer (will add to the cli script later on)
- Removed printing and added direct logging

feat(cli): Moved CLI script to the app

- Move the cli.py into the app and created script entry point in pyproject.toml. From now on you can `pip install .` and just use `codypy` command to run the CLI script.
- Added support for configuring custom enterprise Sourcegraph endpoint

refactor(logging): Using standard python logging
- Instead of the custom log function using standard python logging
- Configuring a logger on the CLI sciprt.

The changes aims to enhance usability of the module in other applications and applying more common python patterns.