### PR TITLE
fix: Convert JSON message to bytes in _send_jsonrpc_request

### DIFF
--- a/codypy/messaging.py
+++ b/codypy/messaging.py
@@ -34,12 +34,14 @@ async def _send_jsonrpc_request(
     }
 
     # Convert the message to JSON string
-    json_message: str = pd.to_json(message).decode()
+    json_message: bytes = pd.to_json(message)
     content_length: int = len(json_message)
-    content_message: str = f"Content-Length: {content_length}\r\n\r\n{json_message}"
+    content_message: bytes = (
+        f"Content-Length: {content_length}\r\n\r\n".encode() + json_message
+    )
 
     # Send the JSON-RPC message to the server
-    writer.write(content_message.encode("utf-8"))
+    writer.write(content_message)
     await writer.drain()
     MESSAGE_ID += 1
 


### PR DESCRIPTION
The `_send_jsonrpc_request` function in `messaging.py` has been updated to handle unicode input from the user, such as non-ASCII characters. The following changes have been made:

- Convert the JSON message to bytes using `pd.to_json(message)` instead of decoding it to a string.
- Create the content message as bytes by encoding the content length header and concatenating it with the JSON message bytes.
- Write the content message bytes directly to the writer instead of encoding it again.

These modifications ensure that the function can properly send messages containing unicode characters to the server without any encoding issues and closes issue Handling non-ascii characters #10 .