### PR TITLE
Update to the latest Cody

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-SRC_ACCESS_TOKEN = "Replace with your Sourcegraph access token here"
-BINARY_PATH = "Replace with the path to the binary here"

--- a/cli.py
+++ b/cli.py
@@ -60,7 +60,7 @@ async def async_main():
 async def chat(args):
     cody_server: CodyServer = await CodyServer.init(
         binary_path=args.binary_path,
-        version="0.0.5b",
+        version="5.5.14",
     )
     # Create an AgentSpecs instance with the specified workspace root URI and extension configuration.
     agent_specs = AgentSpecs(

--- a/codypy/client_info.py
+++ b/codypy/client_info.py
@@ -46,7 +46,7 @@ class ClientCapabilities(BaseModel):
 
 class AgentSpecs(BaseModel):
     name: str = "cody-agent"
-    version: str = "0.0.5b"
+    version: str = "5.5.14"
     workspaceRootUri: str | None = None
 
     # @deprecated Use `workspaceRootUri` instead.
@@ -62,7 +62,7 @@ class AgentSpecs(BaseModel):
     # marketingTracking: TelemetryEventMarketingTrackingInput = None
 
     def __init__(
-        self, name="cody-agent", version="0.0.5b", workspaceRootUri="", **data
+        self, name="cody-agent", version="5.5.14", workspaceRootUri="", **data
     ):
         super().__init__(
             name=name, version=version, workspaceRootUri=workspaceRootUri, **data

--- a/codypy/messaging.py
+++ b/codypy/messaging.py
@@ -262,7 +262,10 @@ async def request_response(method_name: str, params, reader, writer) -> Any:
     logger.debug("Sending command: %s - %s", method_name, params)
     await _send_jsonrpc_request(writer, method_name, params)
     async for response in _handle_server_respones(reader):
-        if response.get("params", {}).get("isMessageInProgress"):
+        params = response.get("params", {})
+        if not isinstance(params, dict):
+            continue
+        if params.get("isMessageInProgress"):
             stream_logger.debug("InProgress response: %s", response)
         if response and await _has_result(response):
             logger.debug("Response: %s", response)

--- a/codypy/server.py
+++ b/codypy/server.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 async def _get_cody_binary(binary_path: str, version: str) -> str:
+    print(f"Checking for Cody Agent binary at {binary_path}")
     has_agent_binary = await _check_for_binary_file(binary_path, "cody-agent", version)
     if not has_agent_binary:
         logger.warning(
@@ -89,7 +90,8 @@ class CodyServer:
             )
         else:
             binary = self.cody_binary
-        args.append("jsonrpc")
+        args.append("api")
+        args.append("jsonrpc-stdio")
         self._process: Process = await asyncio.create_subprocess_exec(
             binary,
             *args,

--- a/codypy/server_info.py
+++ b/codypy/server_info.py
@@ -13,13 +13,10 @@ class CodyLLMSiteConfiguration(BaseModel):
 
 class AuthStatus(BaseModel):
     endpoint: str
-    isDotCom: bool
-    isLoggedIn: bool
     showInvalidAccessTokenError: bool
     authenticated: bool
     hasVerifiedEmail: bool
     requiresVerifiedEmail: bool
-    siteHasCodyEnabled: bool
     siteVersion: str
     userCanUpgrade: bool
     username: str

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ async def main():
     logger.info("--- Create Server Connection ---")
     cody_server: CodyServer = await CodyServer.init(
         binary_path=BINARY_PATH,
-        version="0.0.5b",
+        version="5.5.14",
     )
 
     # Create an AgentSpecs instance with the specified workspace root URI
@@ -41,6 +41,7 @@ async def main():
             "accessToken": SRC_ACCESS_TOKEN,
             "codebase": "",  # "/home/prinova/CodeProjects/codypy",  # github.com/sourcegraph/cody",
             "customConfiguration": {},
+            "cody.experimental.symf.enabled": False,
         },
     )
 


### PR DESCRIPTION
Previously, Codypy was using the old standalone binary distribution of Cody. This was problematic because this distribution is no longer supported and it crashes when using the latest version of Sourcegraph.

This PR updates the code to use the latest supported version of the Cody JSON-RPC protocol. Instead of the old standalone binary, Cody is now only distributed as an `index.js` bundle that is published to npm. This PR downloads the index.js file directly from npm (via tarball download) and creates a script that runs `node package dist/index.js`. This PR also updates the code to fix some Pydantic crashes that are caused by assuming some fields are required when they are optional.